### PR TITLE
Integration of fuzzing and Mayhem with toml-rs

### DIFF
--- a/.github/workflows/mayhem.yaml
+++ b/.github/workflows/mayhem.yaml
@@ -1,0 +1,61 @@
+name: Mayhem
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  PROJECTNAME: toml-rs
+  MAYHEMFILE: Mayhem/fuzz_from_to_string.mayhemfile
+
+jobs:
+  build:
+    name: '${{ matrix.os }} shared=${{ matrix.shared }} ${{ matrix.build_type }}'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        shared: [false]
+        build_type: [Release]
+        include:
+          - os: ubuntu-latest
+            triplet: x64-linux
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          file: Dockerfile.mayhem
+
+      - name: Start analysis for fuzz_from_to_string
+        uses: ForAllSecure/mcode-action@v1
+        with:
+          mayhem-token: ${{ secrets.MAYHEM_TOKEN }}
+          args: --image ${{ steps.meta.outputs.tags }} --project ${{ env.PROJECTNAME }} --file ${{ env.MAYHEMFILE }}
+          sarif-output: sarif
+
+      - name: Upload SARIF file(s)
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: sarif

--- a/Dockerfile.mayhem
+++ b/Dockerfile.mayhem
@@ -1,0 +1,19 @@
+# Use Rust to build
+FROM rustlang/rust:nightly as builder
+
+# Add source code to the build stage.
+ADD . /toml-rs
+WORKDIR /toml-rs
+
+RUN cargo install cargo-fuzz
+
+# BUILD INSTRUCTIONS
+WORKDIR /toml-rs/fuzz
+RUN cargo +nightly fuzz build fuzz_from_to_string
+# Output binaries are placed in /toml-rs/fuzz/target/x86_64-unknown-linux-gnu/release/
+
+# Package Stage -- we package for a plain Ubuntu machine
+FROM --platform=linux/amd64 ubuntu:20.04
+
+# Copy the binary from the build stage to an Ubuntu docker image
+COPY --from=builder /toml-rs/fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_from_to_string /

--- a/Mayhem/fuzz_from_to_string.mayhemfile
+++ b/Mayhem/fuzz_from_to_string.mayhemfile
@@ -1,0 +1,5 @@
+project: toml-rs
+target: fuzz_from_to_string
+
+cmds:
+  - cmd: /fuzz_from_to_string

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,26 @@
+
+[package]
+name = "toml-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.toml]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "fuzz_from_to_string"
+path = "fuzz_targets/fuzz_from_to_string.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/fuzz_from_to_string.rs
+++ b/fuzz/fuzz_targets/fuzz_from_to_string.rs
@@ -1,0 +1,12 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+extern crate toml;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(data) = toml::from_slice::<toml::Value>(data) {
+        let s = toml::to_string(&data).unwrap();
+        let v: toml::Value = toml::from_str(&s).unwrap();
+        let t = toml::to_string(&v).unwrap();
+        assert_eq!(s, t);
+    }
+});

--- a/fuzz/oss-fuzz.sh
+++ b/fuzz/oss-fuzz.sh
@@ -3,4 +3,5 @@
 set -eux
 
 cargo fuzz build -O
+wget https://raw.githubusercontent.com/google/fuzzing/master/dictionaries/toml.dict -O $OUT/fuzz_from_to_string.dict
 cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_from_to_string $OUT/fuzz_from_to_string

--- a/fuzz/oss-fuzz.sh
+++ b/fuzz/oss-fuzz.sh
@@ -2,6 +2,10 @@
 
 set -eux
 
+# https://google.github.io/oss-fuzz/getting-started/new-project-guide/#buildsh
+OUT=${OUT:-out}
+mkdir -p "$OUT"
+
 build_type=${1:-"release"}
 build_args="--release"
 if [[ "$build_type" =~ "dev" ]]; then

--- a/fuzz/oss-fuzz.sh
+++ b/fuzz/oss-fuzz.sh
@@ -3,5 +3,6 @@
 set -eux
 
 cargo fuzz build -O
-wget https://raw.githubusercontent.com/google/fuzzing/master/dictionaries/toml.dict -O $OUT/fuzz_from_to_string.dict
 cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_from_to_string $OUT/fuzz_from_to_string
+wget https://raw.githubusercontent.com/google/fuzzing/master/dictionaries/toml.dict -O $OUT/fuzz_from_to_string.dict
+zip -r $OUT/fuzz_from_to_string_seed_corpus.zip test-suite/tests

--- a/fuzz/oss-fuzz.sh
+++ b/fuzz/oss-fuzz.sh
@@ -2,7 +2,14 @@
 
 set -eux
 
-cargo fuzz build -O --verbose
-cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_from_to_string $OUT/fuzz_from_to_string
+build_type=${1:-"release"}
+build_args="--release"
+if [[ "$build_type" =~ "dev" ]]; then
+    build_type="debug"
+    build_args="--dev"
+fi
+
+cargo fuzz build $build_args --verbose
+cp "fuzz/target/x86_64-unknown-linux-gnu/$build_type/fuzz_from_to_string" $OUT/fuzz_from_to_string
 wget https://raw.githubusercontent.com/google/fuzzing/master/dictionaries/toml.dict -O $OUT/fuzz_from_to_string.dict
 zip -r $OUT/fuzz_from_to_string_seed_corpus.zip test-suite/tests

--- a/fuzz/oss-fuzz.sh
+++ b/fuzz/oss-fuzz.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-cargo fuzz build -O
+cargo fuzz build -O --verbose
 cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_from_to_string $OUT/fuzz_from_to_string
 wget https://raw.githubusercontent.com/google/fuzzing/master/dictionaries/toml.dict -O $OUT/fuzz_from_to_string.dict
 zip -r $OUT/fuzz_from_to_string_seed_corpus.zip test-suite/tests

--- a/fuzz/oss-fuzz.sh
+++ b/fuzz/oss-fuzz.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -eux
+
+cargo fuzz build -O
+cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_from_to_string $OUT/fuzz_from_to_string


### PR DESCRIPTION
Integration of fuzzing and Mayhem (with a GitHub action) with the `toml-rs` project. The fuzzing tests were initially created by evverx, and were pulled directly from their branch. This user attempted to integrate this project with OSS-Fuzz, but at the time of this pull request the project is **not** integrated in OSS-Fuzz. I am unsure if this will go through, but it seems unlikely that it will happen at this point, as the pull request has been dormant for almost 1 year.

The Mayhem integration was straightforward, as the fuzzing binary was created with LibFuzzer. A `Dockerfile`, Mayhemfile, and YAML file containing the Mayhem GitHub action were added to the project.